### PR TITLE
fix: clone header to prevent from endless appending if header is set

### DIFF
--- a/httpclient.go
+++ b/httpclient.go
@@ -239,7 +239,7 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 	}
 
 	if c.header != nil {
-		req.Header = c.header
+		req.Header = c.header.Clone()
 	}
 
 	if len(c.username) > 0 && len(c.password) > 0 {


### PR DESCRIPTION
If the header is set (WithHeader option) the Content-Type will be appended on each request.